### PR TITLE
Added balena compability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN install_packages libftdi-dev libusb-dev
 WORKDIR /app
 
 # Checkout and compile remote code
-COPY builder/* .
+COPY builder/* ./
+RUN chmod +x build.sh
 RUN ARCH=${ARCH} ./build.sh
 
 # Runner image
@@ -53,6 +54,7 @@ COPY --from=builder /usr/local/lib/libmpsse.so /usr/local/lib/libmpsse.so
 COPY --from=builder /usr/local/lib/libmpsse.a /usr/local/lib/libmpsse.a
 COPY --from=builder /usr/local/include/mpsse.h /usr/local/include/mpsse.h
 COPY runner/* ./
+RUN chmod +x *sh
 
 # Launch our binary on container startup.
 CMD ["bash", "start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
-version: '3.7'
+version: '2'
 
 services:
 
   udp-packet-forwarder:
-    
+    # use pre-defined image
     image: rakwireless/udp-packet-forwarder:latest
+    # or comment out image: and build it yourself / with balena services
+    #build:
+    #  context: .
+    #  args:
+    #    ARCH: rpi
+
     container_name: udp-packet-forwarder
     restart: unless-stopped
     privileged: true


### PR DESCRIPTION
Some small changes to allow for deployment via ````balena push````.
docker-compose.yml:
- image parameter needs to be commented out
- build parameter need to be commented in
- also all env variables need to be set correctly

On an RPi end-device, UART needs to be enabled, for the RPi 3 also the dtoverlay "disable-bt" should be loaded to make access of GPS on /dev/ttyAMA0 available, like on other systems.